### PR TITLE
Add OSM attributions

### DIFF
--- a/src/views/ViewColumn.vue
+++ b/src/views/ViewColumn.vue
@@ -105,7 +105,7 @@
         ref="mymap"
         :options="{ scrollWheelZoom: false }"
       >
-        <l-tile-layer :url="url" />
+        <l-tile-layer :url="url" :attribution="attribution" />
       </l-map>
     </div>
 
@@ -241,7 +241,7 @@ export default class ViewColumn extends Vue {
 
   // url = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 
-  // attribution = '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors';
+  attribution = '&copy; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors';
 
   centerFeatures(features: GeoJSON.FeatureCollection) {
     const geoJsonLayer = L.geoJSON(features);


### PR DESCRIPTION
The map is from Mapbox and based on OSM. Something we should not forget is attributions.

As a contributor, OSM attributions are [absolutely required](https://www.openstreetmap.org/copyright).

I think we should also change the map for something more neutral and nicer (I'm not talking about Jawg, even if the pelias project is compatible with our free plan :stuck_out_tongue_closed_eyes:).

Since both Mapbox and Jawg provide geocoding services, [Wikimedia](https://foundation.wikimedia.org/wiki/Maps_Terms_of_Use) seems to be more neutral for a geo-OpenSource project. And their servers seem to be more robust than OSM ones :sweat_smile:.