### PR TITLE
add a way to configure map tiles in static frontend

### DIFF
--- a/src/main-api.ts
+++ b/src/main-api.ts
@@ -1,8 +1,18 @@
 import Vue from 'vue';
 import App from '@/views/App.vue';
+import { getMapConfig } from './map-config';
 
-new Vue({
-  render: (h) => h(App, {
-    props: { isBuiltForApi: true },
-  }),
-}).$mount('#app');
+async function startApp() {
+  const mapConfig = await getMapConfig();
+
+  new Vue({
+    render: (h) => h(App, {
+      props: {
+        isBuiltForApi: true,
+        mapConfig,
+      },
+    }),
+  }).$mount('#app');
+}
+
+startApp();

--- a/src/main-spa.ts
+++ b/src/main-spa.ts
@@ -1,8 +1,13 @@
 import Vue from 'vue';
 import App from '@/views/App.vue';
+import { DefaultMapConfig } from './map-config';
 
 new Vue({
   render: (h) => h(App, {
-    props: { isBuiltForSpa: true, isBuiltForApi: false },
+    props: {
+      isBuiltForSpa: true,
+      isBuiltForApi: false,
+      mapConfig: DefaultMapConfig,
+    },
   }),
 }).$mount('#app');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,11 @@
 import Vue from 'vue';
 import App from '@/views/App.vue';
+import { DefaultMapConfig } from './map-config';
 
 new Vue({
-  render: (h) => h(App),
+  render: (h) => h(App, {
+    props: {
+      mapConfig: DefaultMapConfig,
+    },
+  }),
 }).$mount('#app');

--- a/src/map-config.ts
+++ b/src/map-config.ts
@@ -1,0 +1,38 @@
+export type MapConfig = {
+  tileUrl: string;
+  attribution: string;
+}
+
+export const DefaultMapConfig: MapConfig = {
+  tileUrl: '//{s}.tile.jawg.io/jawg-terrain/{z}/{x}/{y}.png?access-token=t6fAKnvaPdPCucraY88YwlKjBfUHqBMvvZBIWlcp1Z9Z5FVtA02uWo6Dc9DGB2JO',
+  attribution: 'Map &copy; <a href="http://jawg.io" target="_blank" class="jawg-attrib"><b>Jawg</b>Maps</a> | Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" class="osm-attrib">OpenStreetMap contributors</a>',
+};
+
+function maybeFixMapConfig(mapConfig: MapConfig) {
+  // default jawg url is specified with "//" which fails when loading built index.html
+  // as a file
+  if (window.location.protocol === 'file:' && !mapConfig.tileUrl.includes('http:')) {
+    return {
+      ...mapConfig,
+      tileUrl: `http:${mapConfig.tileUrl}`,
+    };
+  }
+  return mapConfig;
+}
+
+async function fetchMapConfig(): Promise<MapConfig> {
+  try {
+    const response = await fetch('/frontend/config');
+    const json: MapConfig = await response.json();
+    if (!json?.tileUrl || !json.attribution) {
+      throw new Error('config mising url or attribution');
+    }
+    return json;
+  } catch {
+    return DefaultMapConfig;
+  }
+}
+
+export async function getMapConfig(): Promise<MapConfig> {
+  return fetchMapConfig().then(maybeFixMapConfig);
+}

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -162,6 +162,7 @@ label {
         :body="response.body"
         :host="response.host"
         :numHosts="hosts.length"
+        :mapConfig="mapConfig"
       />
     </b-row>
 
@@ -171,6 +172,7 @@ label {
         :lat="pointLat"
         :lng="pointLng"
         v-on:point-changed="updatePoint"
+        :mapConfig="mapConfig"
       />
     </b-modal>
 
@@ -188,20 +190,20 @@ import { faMap, faCrosshairs } from '@fortawesome/free-solid-svg-icons';
 
 import BackToTop from 'vue-backtotop';
 
-import * as L from 'leaflet';
-
 /* eslint-disable global-require */
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
 
-// app.js
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
 
+import * as L from 'leaflet';
 import { Icon } from 'leaflet';
 import { LMap, LTileLayer, LMarker } from 'vue2-leaflet';
+import '../../node_modules/leaflet/dist/leaflet.css';
+
 import ViewColumn from './ViewColumn.vue';
 import PointModal from './PointModal.vue';
-import '../../node_modules/leaflet/dist/leaflet.css';
+import { MapConfig } from '../map-config';
 
 import '../main.css';
 
@@ -251,6 +253,8 @@ export default class CompareView extends Vue {
   @Prop() private isBuiltForApi!: boolean;
 
   @Prop() private isBuiltForSpa!: boolean;
+
+  @Prop() private mapConfig!: MapConfig;
 
   ids: string | null = '';
 

--- a/src/views/PointModal.vue
+++ b/src/views/PointModal.vue
@@ -7,7 +7,7 @@
       @click="addMarker"
       ref="mymap"
     >
-      <l-tile-layer :url="url" :attribution="attribution" />
+      <l-tile-layer :url="mapConfig.tileUrl" :attribution="mapConfig.attribution" />
       <l-marker :lat-lng="pointLatLng" v-if="pointLatLng"> </l-marker>
     </l-map>
   </div>
@@ -18,21 +18,21 @@ import {
 } from 'vue-property-decorator';
 import { latLng } from 'leaflet';
 
+import { MapConfig } from '../map-config';
+
 @Component({})
 export default class PointView extends Vue {
   zoom = 5;
 
   defaultCenter = latLng(47.41322, -1.219482);
 
-  url = '//{s}.tile.jawg.io/jawg-terrain/{z}/{x}/{y}.png?access-token=t6fAKnvaPdPCucraY88YwlKjBfUHqBMvvZBIWlcp1Z9Z5FVtA02uWo6Dc9DGB2JO';
-
-  attribution = 'Map &copy; <a href="http://jawg.io" target="_blank" class="jawg-attrib"><b>Jawg</b>Maps</a> | Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" class="osm-attrib">OpenStreetMap contributors</a>';
-
   pointLatLng: L.LatLng | null = null;
 
   @Prop() lat!: number | null;
 
   @Prop() lng!: number | null;
+
+  @Prop() private mapConfig!: MapConfig;
 
   mounted() {
     if (this.lat && this.lng) {

--- a/src/views/ViewColumn.vue
+++ b/src/views/ViewColumn.vue
@@ -124,7 +124,7 @@
         ref="mymap"
         :options="{ scrollWheelZoom: false }"
       >
-        <l-tile-layer :url="tileUrl" :attribution="attribution" />
+        <l-tile-layer :url="mapConfig.tileUrl" :attribution="mapConfig.attribution" />
       </l-map>
     </div>
 
@@ -167,6 +167,7 @@ import AwesomeMarkers from '@/vendor/leaflet.awesome-markers';
 import '@/vendor/leaflet.awesome-markers.css';
 
 import ResultsSummary from './ResultsSummary.vue';
+import { MapConfig } from '../map-config';
 
 const icons = [faWeebly, faDotCircle, faMapSigns, faLanguage, faMap, faObjectUngroup];
 icons.forEach((i) => library.add(i));
@@ -259,17 +260,13 @@ export default class ViewColumn extends Vue {
 
   @Prop() private host!: string;
 
+  @Prop() private mapConfig!: MapConfig;
+
   private renderedJson: any = null;
 
   private summary = '';
 
   center = latLng(47.41322, -1.219482);
-
-  tileUrl =
-    '//{s}.tile.jawg.io/jawg-terrain/{z}/{x}/{y}.png?access-token=t6fAKnvaPdPCucraY88YwlKjBfUHqBMvvZBIWlcp1Z9Z5FVtA02uWo6Dc9DGB2JO';
-
-  attribution =
-    'Map &copy; <a href="http://jawg.io" target="_blank" class="jawg-attrib"><b>Jawg</b>Maps</a> | Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" class="osm-attrib">OpenStreetMap contributors</a>';
 
   centerFeatures(features: GeoJSON.FeatureCollection) {
     const geoJsonLayer = L.geoJSON(features);
@@ -289,12 +286,6 @@ export default class ViewColumn extends Vue {
   }
 
   mounted() {
-    // jawg url is specified with "//" which fails when loading built index.html
-    // as a file
-    if (window.location.protocol === 'file:' && !this.tileUrl.includes('http:')) {
-      this.tileUrl = `http:${this.tileUrl}`;
-    }
-
     renderjson.set_replacer(renderjsonReplacer);
     renderjson.set_show_to_level('all');
 


### PR DESCRIPTION
As discussed in https://github.com/pelias/compare/pull/21 - one issue with the current map tiles in the tool is that they hit a rate limit pretty quickly with no user configurable way to change that.

This change, which I'm not in love with, has the frontend make a query to /frontend/config - if a new map configuration is found there, that is used, otherwise, the default jawg map + key is used.

The idea (which I have verified works) is that pelias/api would serve a chunk of it's config.json (a new section called "frontend") at /frontend/config that would expose these variables, such that the compare tool can be embedded in pelias-api without recompiling