### PR TITLE
add a "run as structured" button to geocoding results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pelias-compare",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "author": "pelias",
   "description": "Pelias geocoder frontend comparison and debugging tool",
   "homepage": "https://github.com/pelias/compare",

--- a/src/vendor/renderjson.js
+++ b/src/vendor/renderjson.js
@@ -7,6 +7,7 @@ Among other things,
   rather than using the icons ⊕ and ⊖
 - it adds the ability to have a replacer function that can change how strings
   are rendered, this is used to linkify GIDs in ViewColumn.vue
+- it adds the ability to linkify keys
 */
 
 /* eslint-disable */
@@ -231,7 +232,7 @@ function _renderjsonhelper(json, indent, dont_indent, show_level, options, path)
       if (!(k in json)) continue;
       append(
         os,
-        themetext(null, indent + "  ", "key", '"' + k + '"', "object syntax", ": "),
+        themetext(null, indent + "  ", "key", '"' + options.key_formatter.call(json, k) + '"', "object syntax", ": "),
         _renderjson(
           options.replacer.call(json, k, json[k], json),
           indent + "  ",
@@ -257,6 +258,12 @@ export default function renderjson(json, idPrefix) {
       : function(k, v) {
           return v;
         };
+  options.key_formatter =
+      typeof options.key_formatter == "function"
+        ? options.key_formatter
+        : function(v) {
+            return v;
+          };
   var pre = append(
     document.createElement("pre"),
     _renderjson(json, "", false, options.show_to_level, options, idPrefix || 'renderjson')
@@ -287,6 +294,10 @@ renderjson.set_replacer = function(replacer) {
   renderjson.options.replacer = replacer;
   return renderjson;
 };
+renderjson.set_key_formatter = function(key_formatter) {
+  renderjson.options.key_formatter = key_formatter;
+  return renderjson;
+};
 renderjson.set_collapse_msg = function(collapse_msg) {
   renderjson.options.collapse_msg = collapse_msg;
   return renderjson;
@@ -306,6 +317,7 @@ renderjson.set_show_by_default(false);
 renderjson.set_sort_objects(false);
 renderjson.set_max_string_length("none");
 renderjson.set_replacer(void 0);
+renderjson.set_key_formatter(void 0);
 renderjson.set_property_list(void 0);
 renderjson.set_collapse_msg(function(len) {
   return len + " item" + (len == 1 ? "" : "s");

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -181,6 +181,7 @@ label {
         :body="response.body"
         :host="response.host"
         :numHosts="hosts.length"
+        :isBuiltForSpa="isBuiltForSpa"
       />
     </b-row>
 

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -386,16 +386,19 @@ export default class CompareView extends Vue {
     this.extraParams = params.toString();
   }
 
-  parseHash() {
-    // If we're running in non-SPA mode with routing like
-    // http://blackmad.github.io/pelias-compare/index.html#/v1/search?text=....
-    let hash = window.location.hash.substr(1);
+  getPathFromUrl(): string {
     // If we're running in SPA mode with routing like
     // http://localhost:8080/v1/search?text=San+Nicolas%2C+Peru&debug=0
     if (this.isBuiltForSpa && window.location.pathname.length > 1) {
-      hash = `/v1/${window.location.href.split('/v1/')[1]}`;
+      return `/v1/${window.location.href.split('/v1/')[1]}`;
     }
+    // If we're running in non-SPA mode with routing like
+    // http://blackmad.github.io/pelias-compare/index.html#/v1/search?text=....
+    return window.location.hash.substr(1);
+  }
 
+  parseHash(_hash: string) {
+    let hash = _hash;
     // As a hueristic, only decode as uri component if there's a uri
     // escaped question mark in there. Copy and pasting a path onto the
     // url hash string won't automatically do this
@@ -434,12 +437,12 @@ export default class CompareView extends Vue {
       }
     }
 
-    this.parseHash();
+    this.parseHash(this.getPathFromUrl());
 
     window.addEventListener(
       'hashchange',
       () => {
-        this.parseHash();
+        this.parseHash(this.getPathFromUrl());
       },
       false,
     );
@@ -543,10 +546,7 @@ export default class CompareView extends Vue {
   }
 
   updateHashFromChild(queryPath: string) {
-    // updqate the hash, parse it out, let that add the parsed hash to the history
-    window.location.hash = queryPath;
-
-    this.parseHash();
+    this.parseHash(queryPath);
 
     this.onSubmit();
   }
@@ -558,7 +558,8 @@ export default class CompareView extends Vue {
       window.history.pushState({}, '', `#${queryPath}`);
     }
 
-    document.title = `Pelias Compare Tool: ${this.text || this.ids || this.point}`;
+
+    document.title = `Pelias Compare Tool: ${this.text || this.ids || this.point || this.endpoint}`;
 
     this.$forceUpdate();
   }
@@ -613,7 +614,6 @@ export default class CompareView extends Vue {
   };
 
   onSubmit() {
-    console.log('calling submit');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const responsePromises: Promise<any>[] = this.hosts.map(async (_host: Tag) => {
       let host = _host.text;

--- a/src/views/ViewColumn.vue
+++ b/src/views/ViewColumn.vue
@@ -665,6 +665,11 @@ export default class ViewColumn extends Vue {
       delete parsedParams.city;
     }
 
+    if (parsedParams.subject) {
+      parsedParams.venue = parsedParams.subject;
+      delete parsedParams.subject;
+    }
+
     const urlSearchParams = new URLSearchParams(parsedParams);
     this.updateHash(`/v1/search/structured?${urlSearchParams.toString()}`);
   }


### PR DESCRIPTION
I added this button while debugging queries like "philadelphia museum of art philadelphia" that I just can't get to return the right results in normal query mode, by jumping into structured, it gives me more control over being able to find the record, use the id for debugging, determine if it's a data/indexing issue, etc etc.

Curious if you think this is useful & are comfortable showing the structured api in a button like this.

![image](https://user-images.githubusercontent.com/445616/88944000-2f428680-d25a-11ea-9812-715fd408d96e.png)

![image](https://user-images.githubusercontent.com/445616/88944091-50a37280-d25a-11ea-8d1a-da209f590513.png)
