### PR TITLE
postalcode icon

### DIFF
--- a/src/views/ResultsSummary.vue
+++ b/src/views/ResultsSummary.vue
@@ -32,6 +32,7 @@ import {
   faCrosshairs,
   faRoad,
   faQuestion,
+  faMailBulk,
 } from '@fortawesome/free-solid-svg-icons';
 import { faCuttlefish } from '@fortawesome/free-brands-svg-icons';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -95,6 +96,8 @@ export default class ResultsSummary extends Vue {
         return faCrosshairs;
       case 'street':
         return faRoad;
+      case 'postalcode':
+        return faMailBulk;
       default:
         return faQuestion;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,14 +2690,14 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001030:
-  version "1.0.30001031"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001031.tgz#76f1bdd39e19567b855302f65102d9a8aaad5930"
-  integrity sha512-DpAP5a1NGRLgYfaNCaXIRyGARi+3tJA2quZXNNA1Du26VyVkqvy2tznNu5ANyN1Y5aX44QDotZSVSUSi2uMGjg==
+  version "1.0.30001228"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz"
+  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001137"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz#6f0127b1d3788742561a25af3607a17fc778b803"
-  integrity sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==
+  version "1.0.30001228"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz"
+  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
simple PR adds an icon for results in the `postalcode` layer which previously showed the default icon.

<img width="301" alt="Screenshot 2021-05-17 at 12 06 24" src="https://user-images.githubusercontent.com/738069/118417472-56dede80-b708-11eb-9c82-ce28e60b65d2.png">
<img width="312" alt="Screenshot 2021-05-17 at 12 06 29" src="https://user-images.githubusercontent.com/738069/118417475-59413880-b708-11eb-9002-5c023fea7912.png">
