### PR TITLE
Display full response body on error

### DIFF
--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -186,6 +186,8 @@ label {
         :key="response.url"
         :url="response.url"
         :body="response.body"
+        :errors="response.errors"
+        :warnings="response.warnings"
         :host="response.host"
         :numHosts="hosts.length"
         :updateHash="updateHashFromChild"
@@ -657,19 +659,16 @@ export default class CompareView extends Vue {
           };
         });
 
-      if (!data || !data.geocoding) {
-        // mock response to reuse the UI logic
+      const errors = data?.geocoding?.errors || [];
+      const warnings = data?.geocoding?.warnings || [];
 
-        let message = 'failed to load json';
+      if (!data?.geocoding) {
+        let message = `HTTP ${status} status from ${host}`;
         if (data && data.error) {
           message = data.error;
         }
 
-        data = {
-          geocoding: {
-            errors: [`${status} ${message}`],
-          },
-        };
+        errors.push(message);
       }
 
       return {
@@ -677,6 +676,8 @@ export default class CompareView extends Vue {
         status,
         host,
         body: data,
+        errors,
+        warnings,
         bodyString: `${JSON.stringify(data, null, 2)}\n\n`,
       };
     });

--- a/src/views/ViewColumn.vue
+++ b/src/views/ViewColumn.vue
@@ -76,14 +76,14 @@
     <div class="messages">
       <div
         class="alert alert-danger"
-        v-for="(message, index) in body.geocoding.errors"
+        v-for="(message, index) in errors"
         :key="index"
       >
         {{ message }}
       </div>
       <div
         class="alert alert-warning"
-        v-for="(message, index) in body.geocoding.warnings"
+        v-for="(message, index) in warnings"
         :key="index"
       >
         {{ message }}
@@ -305,6 +305,10 @@ export default class ViewColumn extends Vue {
   @Prop() private numHosts!: number;
 
   @Prop() private host!: string;
+
+  @Prop() private errors!: Array<string>;
+
+  @Prop() private warnings!: Array<string>;
 
   @Prop() private updateHash!: (s: string) => void;
 


### PR DESCRIPTION
The compare app has always had fairly cryptic messaging when there was an error response from one of the Pelias servers.

It ignores any actual response content from Pelias, and instead displays a static error message ('failed to load json') as well as a bit of synthesized JSON. Neither of these contain much information at all.

**Before**
<img width="456" alt="Screen Shot 2021-06-30 at 11 43 10 AM" src="https://user-images.githubusercontent.com/111716/124014825-d9f68400-d998-11eb-8366-779cbfe7a21c.png">


This PR changes around the behavior so that in the case of any error-like response (really, a response that does not have the `geocoding` section that Pelias generally returns), the actual response body is displayed, which might help debugging.

**After**
<img width="697" alt="Screen Shot 2021-06-30 at 11 47 01 AM" src="https://user-images.githubusercontent.com/111716/124014863-e7137300-d998-11eb-9888-eb75f5fbacc7.png">
